### PR TITLE
Remove compressed view on realestate.com.au

### DIFF
--- a/src/components/realestate.tsx
+++ b/src/components/realestate.tsx
@@ -3,7 +3,7 @@ import type { PlasmoCSUIProps } from 'plasmo';
 import { useEffect, useState, type FC } from 'react';
 import { propertySeeker, seeking } from '~constants';
 import { useIntersectionObserver } from '~hooks/useObserver';
-import { getPrice } from '~services/realestateService';
+import { getPrice } from '~services/realEstateService';
 import { PropertyInsights } from './propertyInsights';
 import { ViewOnGitHub } from './viewOnGitHub';
 import { ViewOnMaps } from './viewOnMaps';

--- a/src/contents/realestateListing.tsx
+++ b/src/contents/realestateListing.tsx
@@ -3,15 +3,20 @@ import styles from 'data-text:../styles/styles.css';
 import type { PlasmoCSConfig, PlasmoGetInlineAnchorList, PlasmoGetStyle } from 'plasmo';
 import { Realestate } from '../components/realestate';
 
-const observer = new MutationObserver(() => {
-  document.querySelectorAll('.residential-card--compressed-view')
-    .forEach((el) => el.classList.remove('residential-card--compressed-view'))
-})
+// contains each li element
+const propertyList = document.querySelector('ul.tiered-results');
 
-observer.observe(document.body, {
-  childList: true,
-  subtree: true
-})
+if (propertyList) {
+  const observer = new MutationObserver(() => {
+    propertyList.querySelectorAll('article.residential-card--compressed-view')
+      .forEach((el) => el.classList.remove('residential-card--compressed-view'));
+  });
+
+  observer.observe(propertyList, {
+    childList: true,
+    subtree: true
+  });
+}
 
 
 export const config: PlasmoCSConfig = {

--- a/src/contents/realestateListing.tsx
+++ b/src/contents/realestateListing.tsx
@@ -3,6 +3,17 @@ import styles from 'data-text:../styles/styles.css';
 import type { PlasmoCSConfig, PlasmoGetInlineAnchorList, PlasmoGetStyle } from 'plasmo';
 import { Realestate } from '../components/realestate';
 
+const observer = new MutationObserver(() => {
+  document.querySelectorAll('.residential-card--compressed-view')
+    .forEach((el) => el.classList.remove('residential-card--compressed-view'))
+})
+
+observer.observe(document.body, {
+  childList: true,
+  subtree: true
+})
+
+
 export const config: PlasmoCSConfig = {
   matches: ['https://www.realestate.com.au/*']
 };

--- a/src/contents/realestateMap.tsx
+++ b/src/contents/realestateMap.tsx
@@ -22,7 +22,7 @@ const RealestateMap = ({ anchor }) => {
   }
 
   return (
-    <div style={{ position: 'absolute', top: '-15px', width: '100%' }}>
+    <div style={{ position: 'absolute', top: '-15px', width: '82%' }}>
       <Realestate anchor={anchor} />
     </div>
   );

--- a/src/contents/realestateMap.tsx
+++ b/src/contents/realestateMap.tsx
@@ -22,7 +22,7 @@ const RealestateMap = ({ anchor }) => {
   }
 
   return (
-    <div style={{ position: 'absolute', top: '-15px', width: '82%' }}>
+    <div style={{ position: 'absolute', top: '-15px', width: '100%' }}>
       <Realestate anchor={anchor} />
     </div>
   );

--- a/src/styles/realestate.css
+++ b/src/styles/realestate.css
@@ -1,7 +1,6 @@
 @container (max-width: 335px) {
   .card-body {
     text-align: left;
-    width: 26.25rem;
   }
 
   .item {

--- a/src/styles/realestate.css
+++ b/src/styles/realestate.css
@@ -1,7 +1,9 @@
 @container (max-width: 335px) {
   .card-body {
     text-align: left;
+    width: 26.25rem;
   }
+
   .item {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Fixed styling when viewing in list view by removing compressed css on realestate.com.au

## Current
![Screenshot current-compressed-list-view](https://github.com/user-attachments/assets/6580eb58-afb9-4a26-af3e-9ec01b94bba0)

## Improved
![Screenshot new-list-view](https://github.com/user-attachments/assets/c24a8fae-385d-4bbf-bfca-2edeb35620ec)




